### PR TITLE
Add homepage sections and copy

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -3,16 +3,13 @@ module Copy.Keys exposing (Key(..))
 
 type Key
     = SiteTitle
-    | SiteFooter
     | Strapline
     | WhatWeDoH2
-    | WhatWeDoP
+    | WhatWeDoMarkdown
+    | ThingsWeWorkOnH2
     | WhoWeAreH2
-    | WhoWeAreP
-    | WhatWeBelieveH2
-    | WhatWeBelieveP
-    | HowMuchWeCostH2
-    | HowMuchWeCostP
-    | HowMuchWeCostUl
-    | HowToContactUsH2
-    | HowToContactUsP
+    | WhoWeAreMarkdown1
+    | WhoWeAreMarkdown2
+    | ContactUsH2
+    | ContactUsMarkdown
+    | CompanyInformation

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -11,53 +11,49 @@ t : Key -> String
 t key =
     case key of
         SiteTitle ->
-            "Cookiewolf Co-op"
-
-        SiteFooter ->
-            "Cookiewolf Co-op Ltd is registered in England & Wales (No. 13865007)"
+            "Cookiewolf"
 
         --- Site Meta
         Strapline ->
-            "Building useful stuff online, together"
+            "Building useful digital tools with you"
 
         WhatWeDoH2 ->
-            "What we do"
+            "What We Do"
 
-        WhatWeDoP ->
-            "We work with small organisations and people to discover, design and build the digital tools they need."
+        WhatWeDoMarkdown ->
+            """
+**Cookiewolf** is a cooperatively-run digital development and design studio. We work with organizations of all sizes.
+
+Our projects are based in true collaboration with our clients, focusing on accessibility, sustainability and inclusivity, delivered on a limited budget.
+            """
 
         WhoWeAreH2 ->
             "Who we are"
 
-        WhoWeAreP ->
-            "We’re a collective of developers, designers, researchers and other folk who understand digital tools, small organisation goals, sustainability and creative thinking. Our solutions focus on accessibility and inclusivity as well as delivering on a limited budget."
-
-        WhatWeBelieveH2 ->
-            "What we believe"
-
-        WhatWeBelieveP ->
+        WhoWeAreMarkdown1 ->
             """
- Collaboration and training is at the core of what we deliver. We work with you to feel confident about maintaining the tools we build together.
-
-We are founders of [Code Reading Club CIC](https://codereading.club), putting reading skills at the forefront of a professional programmer's priorities. We foster a learning culture, allowing for everyone to do things at their own pace and with the support they need.
+An experienced group of developers, designers, writers, and other folk who’ve come together to form a collective. Cookiewolf Co-op reflects how we think businesses should be run, based in equity, flexibility and creative thinking.
             """
 
-        HowMuchWeCostH2 ->
-            "What we cost"
-
-        HowMuchWeCostP ->
-            "We work with you to make the most of your budget. We make sure enough time lapses between decisions to give us the most considered outcome."
-
-        HowMuchWeCostUl ->
+        WhoWeAreMarkdown2 ->
             """
-- **up to £1,000** (within a month) We can get you set up with a DIY solution or improve something you already have.
-- **£5,000** (over a few months) We can build a small app or help you put together a basic website.
-- **£20,000** (over 3-9 months) We can plan and prototype an idea you have and test it out or build a large website with a few bespoke features.
-- **£60,000 +** (up to a year or more) We can do some in depth explorations and try out a few ideas, continuously making improvements in order to reach the best solution.
+Our members’ award-winning work spans medium to large-scale projects with clients across the arts, third sector, B2B, social justice and retail sectors.
+
+[Meet the people behind Cookiewolf](/about-us)
             """
 
-        HowToContactUsH2 ->
-            "How to contact us"
+        ThingsWeWorkOnH2 ->
+            "Things We're Working On"
 
-        HowToContactUsP ->
-            "[hello@cookiewolf.coop](mailto:hello@cookiewolf.coop)"
+        ContactUsH2 ->
+            "Contact Us"
+
+        ContactUsMarkdown ->
+            """
+Got a project? Questions? Just want a chat? Email us at:
+
+[hello@cookiewolf.coop](mailto:hello@cookiewolf.coop)
+            """
+
+        CompanyInformation ->
+            "Cookiewolf Co-op Ltd is registered in England & Wales (No. 13865007)"

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -2,7 +2,7 @@ module Page.Index exposing (view)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
-import Html.Styled exposing (Html, div, h2, p, text)
+import Html.Styled exposing (Html, div, h2, text)
 import Model exposing (Model)
 import Msg exposing (Msg)
 import Theme.View
@@ -12,14 +12,11 @@ view : Model -> Html Msg
 view _ =
     div []
         [ h2 [] [ text (t WhatWeDoH2) ]
-        , p [] [ text (t WhatWeDoP) ]
+        , Theme.View.markdownToHtml (t WhatWeDoMarkdown)
+        , h2 [] [ text (t ThingsWeWorkOnH2) ]
+        , div [] [ text "[cCc] Case study list #23" ]
         , h2 [] [ text (t WhoWeAreH2) ]
-        , p [] [ text (t WhoWeAreP) ]
-        , h2 [] [ text (t WhatWeBelieveH2) ]
-        , Theme.View.markdownToHtml (t WhatWeBelieveP)
-        , h2 [] [ text (t HowMuchWeCostH2) ]
-        , p [] [ text (t HowMuchWeCostP) ]
-        , Theme.View.markdownToHtml (t HowMuchWeCostUl)
-        , h2 [] [ text (t HowToContactUsH2) ]
-        , Theme.View.markdownToHtml (t HowToContactUsP)
+        , Theme.View.markdownToHtml (t WhoWeAreMarkdown1)
+        , div [] [ text "[cCc] Who we are list #24" ]
+        , Theme.View.markdownToHtml (t WhoWeAreMarkdown2)
         ]

--- a/src/Theme/View.elm
+++ b/src/Theme/View.elm
@@ -3,7 +3,7 @@ module Theme.View exposing (markdownToHtml, viewPageWrapper)
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Css exposing (..)
-import Html.Styled exposing (Html, div, h1, img, text)
+import Html.Styled exposing (Html, div, h1, h2, img, p, text)
 import Html.Styled.Attributes exposing (alt, css, id, src)
 import Markdown
 import Msg exposing (Msg)
@@ -39,7 +39,11 @@ viewPageHeader =
 
 viewPageFooter : Html Msg
 viewPageFooter =
-    div [ css [ footerStyle ] ] [ text (t SiteFooter) ]
+    div [ css [ footerStyle ] ]
+        [ h2 [] [ text (t ContactUsH2) ]
+        , markdownToHtml (t ContactUsMarkdown)
+        , p [] [ text (t CompanyInformation) ]
+        ]
 
 
 pagewrapperStyle : Style


### PR DESCRIPTION
Fixes #19 

## Description

- Adds home page copy and sections
- Adds footer copy

## Checklist

If any left un-ticked, consider raising a tech debt issue.

- [x] Best efforts have been made towards __accessibility__
- [ ] __Test coverage__ has been added for any new functionality
- [ ] All existing __tests pass__
- [x] Changes have been manually __verified locally__
- [x] Relevant __documentation__ has been updated to reflect changes
- [x] Any placeholder UI __copy__ has been approved or flagged for review
