### PR TITLE
About us page with expanders & profile stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We're using [elm-test-rs](https://github.com/mpizenberg/elm-test-rs) to run [elm
 
 - UI text and meta text values are stored in `Copy.Text` and can render as html from markdown
 - Case Study text is in `Copy.CaseStudy` and must contain values for the required fields
+- About Us profile text is in `Copy.AboutUs`
 - Page templates for each `Route` are defined in e.g. `Page.Index` and `Page.CaseStudy`
 
 ### Styling & layouts

--- a/src/Copy/AboutUs.elm
+++ b/src/Copy/AboutUs.elm
@@ -1,0 +1,93 @@
+module Copy.AboutUs exposing (profiles)
+
+import Copy.Keys exposing (Section(..))
+import Model
+
+
+profiles : List Model.ProfileInfo
+profiles =
+    [ alfie, emma, ivan, karl, katja, nick, rebecca, stuart ]
+
+
+alfie : Model.ProfileInfo
+alfie =
+    { section = DigitalDevelopment
+    , name = "Alfie"
+    , role = ""
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+emma : Model.ProfileInfo
+emma =
+    { section = ContentAndDesign
+    , name = "Emma"
+    , role = ""
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+ivan : Model.ProfileInfo
+ivan =
+    { section = DigitalDevelopment
+    , name = "Ivan"
+    , role = ""
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+karl : Model.ProfileInfo
+karl =
+    { section = Business
+    , name = "Karl"
+    , role = "Delivery Manager & Software Tester"
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+katja : Model.ProfileInfo
+katja =
+    { section = DigitalDevelopment
+    , name = "Katja"
+    , role = ""
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+nick : Model.ProfileInfo
+nick =
+    { section = DigitalDevelopment
+    , name = "Nick"
+    , role = ""
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+rebecca : Model.ProfileInfo
+rebecca =
+    { section = ContentAndDesign
+    , name = "Rebecca"
+    , role = ""
+    , bioMarkdown = ""
+    , projectsMarkdown = ""
+    }
+
+
+stuart : Model.ProfileInfo
+stuart =
+    { section = Business
+    , name = "Stuart"
+    , role = "Business Development & Digital Specialist"
+    , bioMarkdown = """
+Stuart is a UX and service design specialist with a focus on project and product management. As a visual artist himself, he's particularly interested in working on digital projects for arts and social justice organisations.  Stuart's work with Foyer has also seen him nominated for multiple awards, including being longlisted for the 'Digital Ambassador' award in the 2025 Digital Cultural Awards.
+    """
+    , projectsMarkdown = """
+ The Foundling Museum, South London Gallery, Art UK, Surviving Economic Abuse, Standing Together Against Domestic Abuse, Manchester Museum.
+    """
+    }

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -1,8 +1,14 @@
-module Copy.Keys exposing (ContentType(..), Key(..))
+module Copy.Keys exposing (ContentType(..), Key(..), Section(..))
 
 
 type ContentType
     = CaseStudy
+
+
+type Section
+    = Business
+    | ContentAndDesign
+    | DigitalDevelopment
 
 
 type
@@ -18,6 +24,11 @@ type
     | WhoWeAreHeading
     | WhoWeAreMarkdown1
     | WhoWeAreMarkdown2
+      -- About Us
+    | AboutUsSlug
+    | AboutUsTitle
+    | AboutUsSection Section
+    | AboutUsProfileProjectsLabel
       -- Case Study
     | CaseStudySlug
     | WhatWeDidHeading

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,6 +1,6 @@
 module Copy.Text exposing (t)
 
-import Copy.Keys exposing (ContentType(..), Key(..))
+import Copy.Keys exposing (ContentType(..), Key(..), Section(..))
 
 
 
@@ -50,6 +50,26 @@ Our members’ award-winning work spans medium to large-scale projects with clie
 
         ThingsWeWorkOnHeading ->
             "Things We're Working On"
+
+        AboutUsSlug ->
+            "about-us"
+
+        AboutUsTitle ->
+            "About Us"
+
+        AboutUsSection section ->
+            case section of
+                Business ->
+                    "Business"
+
+                ContentAndDesign ->
+                    "Content And Design"
+
+                DigitalDevelopment ->
+                    "Digital Development"
+
+        AboutUsProfileProjectsLabel ->
+            "**Selected clients**: "
 
         CaseStudySlug ->
             "case-study"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -8,9 +8,11 @@ import Copy.Text exposing (t)
 import Html.Styled exposing (Html, toUnstyled)
 import Model exposing (Model)
 import Msg exposing (Msg(..))
+import Page.AboutUs
 import Page.CaseStudy
 import Page.Index
 import Route exposing (Route(..))
+import Set
 import Theme.View
 import Url
 
@@ -40,6 +42,7 @@ init _ url key =
     in
     ( { key = key
       , page = Maybe.withDefault Index maybeRoute
+      , openSections = Set.empty
       }
     , Cmd.none
     )
@@ -48,6 +51,17 @@ init _ url key =
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+        SectionToggled sectionSlug ->
+            let
+                newOpenSections =
+                    if Set.member sectionSlug model.openSections then
+                        Set.remove sectionSlug model.openSections
+
+                    else
+                        Set.insert sectionSlug model.openSections
+            in
+            ( { model | openSections = newOpenSections }, Cmd.none )
+
         UrlChanged url ->
             let
                 newRoute : Route
@@ -86,6 +100,9 @@ view model =
     case model.page of
         Index ->
             Theme.View.viewPageWrapper (t SiteTitle) (Page.Index.view model)
+
+        AboutUs ->
+            Theme.View.viewPageWrapper (t AboutUsTitle) (Page.AboutUs.view model)
 
         CaseStudy slug ->
             let

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,12 +1,15 @@
-module Model exposing (CaseStudy, Image, Model, Quote)
+module Model exposing (CaseStudy, Image, Model, ProfileInfo, Quote)
 
 import Browser.Navigation
+import Copy.Keys
 import Route exposing (Route)
+import Set exposing (Set)
 
 
 type alias Model =
     { key : Browser.Navigation.Key
     , page : Route
+    , openSections : Set String
     }
 
 
@@ -32,4 +35,13 @@ type alias CaseStudy =
     , maybeWhatWeDidImage : Maybe Image
     , resultsMarkdown : String
     , maybeQuote : Maybe Quote
+    }
+
+
+type alias ProfileInfo =
+    { section : Copy.Keys.Section
+    , name : String
+    , role : String
+    , bioMarkdown : String
+    , projectsMarkdown : String
     }

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -1,9 +1,11 @@
 module Msg exposing (Msg(..))
 
 import Browser
+import Copy.Keys
 import Url
 
 
 type Msg
-    = UrlChanged Url.Url
+    = SectionToggled String
+    | UrlChanged Url.Url
     | LinkClicked Browser.UrlRequest

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -1,7 +1,6 @@
 module Msg exposing (Msg(..))
 
 import Browser
-import Copy.Keys
 import Url
 
 

--- a/src/Page/AboutUs.elm
+++ b/src/Page/AboutUs.elm
@@ -1,0 +1,110 @@
+module Page.AboutUs exposing (view)
+
+import Copy.AboutUs
+import Copy.Keys exposing (Key(..), Section(..))
+import Copy.Text exposing (t)
+import Css exposing (Style, batch)
+import Html.Styled exposing (Html, a, button, div, h1, h2, h3, h4, p, section, text)
+import Html.Styled.Attributes exposing (attribute, class, css, href, id)
+import Html.Styled.Events exposing (onClick)
+import Model exposing (Model)
+import Msg exposing (Msg)
+import Route
+import Set
+import Theme.Style
+import Theme.View
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ h1 [] [ text (t AboutUsTitle) ]
+        , div [] (viewProfileSections model)
+        ]
+
+
+viewProfileSection : Model -> Section -> List Model.ProfileInfo -> Html Msg
+viewProfileSection model profileSection profiles =
+    div []
+        [ h2 []
+            [ button
+                [ id (headerIdFromSection profileSection)
+                , if Set.member (slugFromSection profileSection) model.openSections then
+                    attribute "aria-expanded" "true"
+
+                  else
+                    attribute "aria-expanded" "false"
+                , attribute "aria-controls" (contentIdFromSection profileSection)
+                , onClick (Msg.SectionToggled (slugFromSection profileSection))
+                ]
+                [ text (t (AboutUsSection profileSection))
+                ]
+            ]
+        , section
+            [ id (contentIdFromSection profileSection)
+            , attribute "aria-labelledby" (headerIdFromSection profileSection)
+            , if Set.member (slugFromSection profileSection) model.openSections then
+                css [ Theme.Style.visuallyHiddenStyles ]
+
+              else
+                css []
+            ]
+            (viewProfiles profiles)
+        ]
+
+
+viewProfile : Model.ProfileInfo -> List (Html Msg)
+viewProfile profile =
+    [ h3 [] [ text profile.name ]
+    , h4 [] [ text profile.role ]
+    , div [] [ Theme.View.markdownToHtml profile.bioMarkdown ]
+    , div [] [ Theme.View.markdownToHtml (t AboutUsProfileProjectsLabel ++ profile.projectsMarkdown) ]
+    ]
+
+
+viewProfileSections : Model -> List (Html Msg)
+viewProfileSections model =
+    List.map
+        (\profileSection ->
+            List.filter
+                (\profile ->
+                    profile.section == profileSection
+                )
+                Copy.AboutUs.profiles
+                |> viewProfileSection model profileSection
+        )
+        [ Business, ContentAndDesign, DigitalDevelopment ]
+
+
+viewProfiles : List Model.ProfileInfo -> List (Html Msg)
+viewProfiles profiles =
+    List.concat
+        (List.map
+            (\profile ->
+                viewProfile profile
+            )
+            profiles
+        )
+
+
+headerIdFromSection : Section -> String
+headerIdFromSection profileSection =
+    "header-"
+        ++ slugFromSection profileSection
+
+
+contentIdFromSection : Section -> String
+contentIdFromSection profileSection =
+    "content-"
+        ++ slugFromSection profileSection
+
+
+slugFromSection : Section -> String
+slugFromSection profileSection =
+    slugify (t (AboutUsSection profileSection))
+
+
+slugify : String -> String
+slugify rawString =
+    String.toLower rawString
+        |> String.replace " " "-"

--- a/src/Page/AboutUs.elm
+++ b/src/Page/AboutUs.elm
@@ -3,13 +3,11 @@ module Page.AboutUs exposing (view)
 import Copy.AboutUs
 import Copy.Keys exposing (Key(..), Section(..))
 import Copy.Text exposing (t)
-import Css exposing (Style, batch)
-import Html.Styled exposing (Html, a, button, div, h1, h2, h3, h4, p, section, text)
-import Html.Styled.Attributes exposing (attribute, class, css, href, id)
+import Html.Styled exposing (Html, button, div, h1, h2, h3, h4, section, text)
+import Html.Styled.Attributes exposing (attribute, css, id)
 import Html.Styled.Events exposing (onClick)
 import Model exposing (Model)
 import Msg exposing (Msg)
-import Route
 import Set
 import Theme.Style
 import Theme.View

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -8,6 +8,7 @@ import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)
 
 type Route
     = Index
+    | AboutUs
     | CaseStudy String
 
 
@@ -23,6 +24,9 @@ toString route =
         Index ->
             "/"
 
+        AboutUs ->
+            t AboutUsSlug
+
         CaseStudy slug ->
             "/" ++ t CaseStudySlug ++ "/" ++ slug
 
@@ -31,5 +35,6 @@ routeParser : Parser (Route -> a) a
 routeParser =
     oneOf
         [ map Index top
+        , map AboutUs (s (t AboutUsSlug))
         , map CaseStudy (s (t CaseStudySlug) </> string)
         ]

--- a/src/Theme/Style.elm
+++ b/src/Theme/Style.elm
@@ -1,8 +1,9 @@
-module Theme.Style exposing (globalStyles, green, withMediaTablet)
+module Theme.Style exposing (globalStyles, green, visuallyHiddenStyles, withMediaTablet)
 
 import Css exposing (..)
 import Css.Global exposing (adjacentSiblings, global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
+import Css.Transitions
 import Html.Styled exposing (Html)
 
 
@@ -23,6 +24,21 @@ green =
 pink : { light : Color, mid : Color, dark : Color }
 pink =
     { light = hex "FFF0FD", mid = hex "EEC5E8", dark = hex "AF1495" }
+
+
+
+-- Utilities
+
+
+visuallyHiddenStyles : Style
+visuallyHiddenStyles =
+    batch
+        [ height (px 1)
+        , overflow hidden
+        , position absolute
+        , whiteSpace noWrap
+        , width (px 1)
+        ]
 
 
 

--- a/src/Theme/Style.elm
+++ b/src/Theme/Style.elm
@@ -3,7 +3,6 @@ module Theme.Style exposing (globalStyles, green, visuallyHiddenStyles, withMedi
 import Css exposing (..)
 import Css.Global exposing (adjacentSiblings, global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
-import Css.Transitions
 import Html.Styled exposing (Html)
 
 


### PR DESCRIPTION
Fixes #21

## Description

- Adds unstyled markup for about us page
- Adds stubs for profile copy

## Checklist

If any left un-ticked, consider raising a tech debt issue.

- [x] Best efforts have been made towards __accessibility__
- [ ] __Test coverage__ has been added for any new functionality
- [x] All existing __tests pass__
- [x] Changes have been manually __verified locally__
- [ ] Relevant __documentation__ has been updated to reflect changes
- [x] Any placeholder UI __copy__ has been approved or flagged for review

## Screenshot if relevant (e.g. UI has changed)
![image](https://github.com/user-attachments/assets/503b1b7b-878b-47d8-b423-d1a138ca4883)


## Additional notes
**Copy for profiles needs adding in**
