### PR TITLE
Add copy for about us

### DIFF
--- a/src/Copy/AboutUs.elm
+++ b/src/Copy/AboutUs.elm
@@ -13,9 +13,13 @@ alfie : Model.ProfileInfo
 alfie =
     { section = DigitalDevelopment
     , name = "Alfie"
-    , role = ""
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , role = "Full Stack Developer & DevOps"
+    , bioMarkdown = """
+Alfie believes that problems are best solved by giving those affected the tools and resources to do so for themselves. He has worked on building infrastructure that promotes community autonomy and resilience for many years. Previously physically and materially, currently digitally.
+    """
+    , projectsMarkdown = """
+Ivan and Alfie had key development roles on PlaceCal, an award-winning community calendar system, developed with Geeks for Social Change and used by communities like TransDimension and Manchester Age Friendly Neighbourhoods.
+    """
     }
 
 
@@ -23,9 +27,13 @@ emma : Model.ProfileInfo
 emma =
     { section = ContentAndDesign
     , name = "Emma"
-    , role = ""
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , role = "Graphic Designer, Illustrator & UX Designer"
+    , bioMarkdown = """
+Emma has over a decade of experience working across the education, arts, culture and charity sectors. [Her graphic and branding work](https://www.emmacharleston.co.uk/) spans print and digital, website and app wireframes, qualitative and quantitative user and client research. She’s particularly interested in collaborative and community-led design practice that’s informed by local circumstance and experience. 
+    """
+    , projectsMarkdown = """
+    The Wildlife Trusts, The Bishopsgate Institute, Happy Valley Pride, Kings Education, Hopscotch Consultancy, The Global Returns Project, Build Concierge, Central London Samaritans
+    """
     }
 
 
@@ -33,9 +41,13 @@ ivan : Model.ProfileInfo
 ivan =
     { section = DigitalDevelopment
     , name = "Ivan"
-    , role = ""
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , role = "Full Stack Developer & DevOps"
+    , bioMarkdown = """
+ Ivan’s focus is software engineering with Ruby on Rails, perl, labview, common lisp and unity. He's also had stabs at javascript and python. He’s interested in Tech for Good and generally fostering community among the queer, nerdy and disabled.
+    """
+    , projectsMarkdown = """
+Ivan and Alfie had key development roles on PlaceCal, an award-winning community calendar system, developed with Geeks for Social Change and used by communities like TransDimension and Manchester Age Friendly Neighbourhoods.
+    """
     }
 
 
@@ -44,8 +56,12 @@ karl =
     { section = Business
     , name = "Karl"
     , role = "Delivery Manager & Software Tester"
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , bioMarkdown = """
+Karl has 30 years’ experience in the tech industry working in financial services and the charity sector. He’s interested in tech projects that empower people, including those who don’t see themselves as ‘techy’  to access help when they need it most. 
+    """
+    , projectsMarkdown = """
+[Alexandra Rose Charity](https://www.alexandrarose.org.uk/), delivering digital infrastructure, replacing a paper-based system, streamlining the existing voucher distribution process to give low-income families access to fresh fruit and vegetables. Other projects include: The Haven, and the [DocReady app](https://docready.org), a Comic Relief lab project.
+    """
     }
 
 
@@ -53,9 +69,13 @@ katja : Model.ProfileInfo
 katja =
     { section = DigitalDevelopment
     , name = "Katja"
-    , role = ""
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , role = "Full Stack Developer & Project Lead"
+    , bioMarkdown = """
+Katja’s career has spanned many interests and industries but currently she designs and implements digital services and browser-based tools that help improve the reach of charities and community organisations. She values a culture of collaboration, open source, transparency, integrity, sharing stuff and giving everyone a chance at meaningful participation. 
+    """
+    , projectsMarkdown = """
+Darts, a series of web games created with Nick for an arts charity on a small budget. You can play them [here](https://games.thepoint.org.uk/). Other recent work includes: Radical Routes, Surviving Economic Abuse, Farm Carbon Calculator
+    """
     }
 
 
@@ -63,9 +83,13 @@ nick : Model.ProfileInfo
 nick =
     { section = DigitalDevelopment
     , name = "Nick"
-    , role = ""
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , role = "Front-end Web Developer"
+    , bioMarkdown = """
+Nick’s background is in games development and he likes to work on projects that genuinely help people, He values semantically correct HTML, creating responsive layouts with CSS and has a special interest in web accessibility.
+    """
+    , projectsMarkdown = """
+[Mind of my Own](https://mindofmyown.org.uk/): By the end of this six-year project with Neontribe, Nick had become Lead Front-end Developer, creating apps that make it safe and intuitive for young people living within the care system to raise safeguarding concerns.
+    """
     }
 
 
@@ -73,9 +97,13 @@ rebecca : Model.ProfileInfo
 rebecca =
     { section = ContentAndDesign
     , name = "Rebecca"
-    , role = ""
-    , bioMarkdown = ""
-    , projectsMarkdown = ""
+    , role = "Writer & Content Designer"
+    , bioMarkdown = """
+Rebecca has worked as a copywriter, bid writer, editor and content designer for over a decade, working on everything from editing poetry anthologies written by at-risk young people, to user-focused copy for websites and apps.
+    """
+    , projectsMarkdown = """
+Shelter, UsVsTh3m; bid writing for Geeks for Social Change and agency work for Saatchi & Saatchi pro, Agency Inc and Pebble Studios.
+    """
     }
 
 

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -69,7 +69,7 @@ Our members’ award-winning work spans medium to large-scale projects with clie
                     "Digital Development"
 
         AboutUsProfileProjectsLabel ->
-            "**Selected clients**: "
+            "**Selected projects**: "
 
         CaseStudySlug ->
             "case-study"


### PR DESCRIPTION
Fixes #21

## Description

- Add remaining copy for about us page

## Checklist

If any left un-ticked, consider raising a tech debt issue.

- [x] Best efforts have been made towards __accessibility__
- [ ] __Test coverage__ has been added for any new functionality
- [x] All existing __tests pass__
- [x] Changes have been manually __verified locally__
- [x] Relevant __documentation__ has been updated to reflect changes
- [x] Any placeholder UI __copy__ has been approved or flagged for review

## Screenshot if relevant (e.g. UI has changed)

## Additional notes
