### PR TITLE
Add footer styles

### DIFF
--- a/src/Theme/Style.elm
+++ b/src/Theme/Style.elm
@@ -1,7 +1,7 @@
-module Theme.Style exposing (black, globalStyles, green, visuallyHiddenStyles, white, withMediaTablet)
+module Theme.Style exposing (black, globalStyles, green, pink, visuallyHiddenStyles, white, withMediaTablet)
 
 import Css exposing (..)
-import Css.Global exposing (adjacentSiblings, global, typeSelector)
+import Css.Global exposing (a, adjacentSiblings, descendants, footer, global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
 
@@ -75,9 +75,9 @@ globalStyles =
             , color pink.dark
             , textDecoration none
             , hover
-                [ borderBottom3 (px 2) dotted pink.dark
+                [ backgroundColor pink.light
+                , borderBottom3 (px 2) dotted pink.dark
                 , color pink.dark
-                , fontWeight (int 700)
                 ]
             ]
         , typeSelector "b"
@@ -94,6 +94,19 @@ globalStyles =
             [ adjacentSiblings
                 [ typeSelector "blockquote"
                     [ marginTop (rem 1)
+                    ]
+                ]
+            ]
+        , footer
+            [ descendants
+                [ a
+                    [ borderBottom3 (px 2) dotted white
+                    , color white
+                    , hover
+                        [ backgroundColor transparent
+                        , borderBottom3 (px 2) dotted pink.mid
+                        , color pink.mid
+                        ]
                     ]
                 ]
             ]

--- a/src/Theme/View.elm
+++ b/src/Theme/View.elm
@@ -3,17 +3,17 @@ module Theme.View exposing (markdownToHtml, viewPageWrapper)
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Css exposing (..)
-import Html.Styled exposing (Html, a, div, h2, header, p, text)
+import Html.Styled exposing (Html, a, div, footer, h2, header, p, text)
 import Html.Styled.Attributes exposing (css, href, id)
 import Markdown
 import Msg exposing (Msg)
-import Theme.Style exposing (black, globalStyles, green, white, withMediaTablet)
+import Theme.Style exposing (black, globalStyles, green, pink, white, withMediaTablet)
 import VitePluginHelper
 
 
 viewPageWrapper : String -> Html Msg -> Html Msg
 viewPageWrapper pageTitle pageContent =
-    div [ id ("page-" ++ generateId pageTitle) ]
+    div [ id ("page-" ++ generateId pageTitle), css [ viewPageStyle ] ]
         [ globalStyles
         , viewPageHeader
         , div [ css [ containerStyle ] ] [ pageContent ]
@@ -37,17 +37,21 @@ viewPageHeader =
 
 viewPageFooter : Html Msg
 viewPageFooter =
-    div [ css [ footerStyle ] ]
-        [ h2 [] [ text (t ContactUsHeading) ]
-        , markdownToHtml (t ContactUsMarkdown)
-        , p [] [ text (t CompanyInformation) ]
+    footer [ css [ footerStyle ] ]
+        [ div [ css [ contentContainer ] ]
+            [ h2 [ css [ footerHeadingStyle ] ] [ text (t ContactUsHeading) ]
+            , div []
+                [ markdownToHtml (t ContactUsMarkdown)
+                ]
+            , p [ css [ footerInfoStyle ] ] [ text (t CompanyInformation) ]
+            ]
         ]
 
 
 contentContainer : Style
 contentContainer =
     batch
-        [ margin4 zero auto (rem 0.5) auto
+        [ margin2 zero auto
         , maxWidth (px 1000)
         , width (pct 100)
         ]
@@ -72,18 +76,32 @@ pageHeaderBackgroundStyle =
     backgroundColor green.dark
 
 
+viewPageStyle : Style
+viewPageStyle =
+    batch
+        [ displayFlex
+        , flexDirection column
+        , height (vh 100)
+        ]
+
+
 headingStyle : Style
 headingStyle =
     batch
-        [ color white
+        [ borderBottom (px 0)
+        , color white
         , fontSize (rem 2.6)
         , fontWeight (int 700)
         , outline none
         , padding zero
         , textAlign center
         , textTransform uppercase
-        , withMediaTablet
-            [ fontSize (rem 4.2) ]
+        , withMediaTablet [ fontSize (rem 4.2) ]
+        , hover
+            [ backgroundColor transparent
+            , borderBottom (px 0)
+            , color green.light
+            ]
         ]
 
 
@@ -110,9 +128,26 @@ containerStyle =
 footerStyle : Style
 footerStyle =
     batch
-        [ fontSize (rem 0.75)
-        , paddingTop (rem 2)
+        [ backgroundColor green.dark
+        , color white
+        , marginTop auto
+        , padding4 (rem 2) (rem 2) (rem 3) (rem 2)
         , textAlign center
+        ]
+
+
+footerHeadingStyle : Style
+footerHeadingStyle =
+    batch
+        [ marginBottom (rem 1)
+        ]
+
+
+footerInfoStyle : Style
+footerInfoStyle =
+    batch
+        [ color pink.mid
+        , marginTop (rem 3)
         ]
 
 


### PR DESCRIPTION
Fixes #37

## Description

- Adds styles to the footer
- It's difficult to target an element inside html from markdown as there's nothing to attach styles to, so I've used the global sheet for this for now. I'll see if any better techniques arise from other tickets.

## Checklist

If any left un-ticked, consider raising a tech debt issue.

- [x] Best efforts have been made towards __accessibility__
- [ ] __Test coverage__ has been added for any new functionality
- [ ] All existing __tests pass__
- [x] Changes have been manually __verified locally__
- [ ] Relevant __documentation__ has been updated to reflect changes
- [ ] Any placeholder UI __copy__ has been approved or flagged for review

## Screenshot if relevant (e.g. UI has changed)

<img width="199" alt="image" src="https://github.com/user-attachments/assets/2c2b18ac-8fda-45cb-b90f-581a351e8fb7" />

## Additional notes
