### PR TITLE
Navigate to anchor with open profile if fragment

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -43,11 +43,20 @@ init _ url key =
         route : Route
         route =
             Maybe.withDefault Index <| Route.fromUrl url
+
+        openSections : Set.Set String
+        openSections =
+            case url.fragment of
+                Just aFragment ->
+                    Set.fromList [ aFragment ]
+
+                Nothing ->
+                    Set.empty
     in
     ( { key = key
       , page = route
       , viewportHeightWidth = ( 800, 800 )
-      , openSections = Set.empty
+      , openSections = openSections
       }
     , Cmd.batch
         [ MetaTags.setMetadata <| MetaTags.metaForPage route
@@ -90,8 +99,17 @@ update msg model =
                     -- If not a valid route, go to index
                     -- could 404 instead depends on desired behaviour
                     Maybe.withDefault Index (Route.fromUrl url)
+
+                openSections : Set.Set String
+                openSections =
+                    case url.fragment of
+                        Just aFragment ->
+                            Set.fromList [ aFragment ]
+
+                        Nothing ->
+                            Set.empty
             in
-            ( { model | page = newRoute }
+            ( { model | page = newRoute, openSections = openSections }
             , MetaTags.setMetadata <| MetaTags.metaForPage newRoute
             )
 

--- a/src/Page/AboutUs.elm
+++ b/src/Page/AboutUs.elm
@@ -41,7 +41,7 @@ viewProfile model profile =
             Tuple.second model.viewportHeightWidth < Theme.Style.maxMobile
     in
     [ if isSmallScreen then
-        h3 []
+        h3 [ id sectionId ]
             [ button
                 [ id ("header-" ++ sectionId)
                 , if Set.member sectionId model.openSections then

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -6,7 +6,8 @@ import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Css exposing (..)
 import Html.Styled exposing (Html, a, div, h2, h3, img, li, p, section, text, ul)
-import Html.Styled.Attributes exposing (alt, class, css, href, src)
+import Html.Styled.Attributes exposing (alt, class, css, href, src, target)
+import Html.Styled.Events exposing (onClick)
 import Model
 import Msg exposing (Msg)
 import Theme.Style exposing (fuchsia, pink, white)
@@ -92,7 +93,11 @@ viewWhoWeAreList profiles =
     List.map
         (\profile ->
             li [ class "profile-item" ]
-                [ a [ href ("/about-us#" ++ generateId profile.name), class "profile-link" ]
+                [ a
+                    [ href ("/about-us#" ++ generateId profile.name)
+                    , class "profile-link"
+                    , Html.Styled.Attributes.target "_self"
+                    ]
                     [ viewProfileImage profile
                     , div [ css [ overlayStyle ] ] []
                     , div [ css [ overlayLabelStyle ] ] [ text profile.name ]


### PR DESCRIPTION
Fixes #27 

## Description

- On a small screen, a fragment in the url opens that section
- Navigating to `/about-us` with a fragment included focusses that element at the top of the page

## Checklist

If any left un-ticked, consider raising a tech debt issue.

- [x] Best efforts have been made towards __accessibility__
- [ ] __Test coverage__ has been added for any new functionality
- [x] All existing __tests pass__
- [x] Changes have been manually __verified locally__
- [x] Relevant __documentation__ has been updated to reflect changes
- [x] Any placeholder UI __copy__ has been approved or flagged for review


## Additional notes
@Nikomus can you flag up any accessibility issues with this method of navigating to the anchors.
